### PR TITLE
Update shrimple.cpp

### DIFF
--- a/shrimple.cpp
+++ b/shrimple.cpp
@@ -300,7 +300,7 @@ std::string shrimplify(std::string input)
         {
             out += ":regional_indicator_";
             out += char_tolower(working[0]);
-            out += ":";
+            out += ": ";
         }
         else
         {


### PR DESCRIPTION
to keep the indicators separate to avoid ligatures